### PR TITLE
Enables auto-merge before approving PR

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -15,13 +15,13 @@ jobs:
         uses: dependabot/fetch-metadata@bfc19f43c126171ed783cdcf9a125055b7831d32
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-      - name: Approve PR
-        run: gh pr review --approve "$PR_URL"
+      - name: Enable auto-merge
+        run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      - name: Enable auto-merge
-        run: gh pr merge --auto --merge "$PR_URL"
+      - name: Approve PR
+        run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Auto merge can only be enabled *before* requirements are met. If the only requirement is approval, and the PR is approved first, then auto merge cannot be enabled.

This reverses the order, so auto-merge is enabled first, and then the PR is approved. This way auto-merge works when the only requirement is approval.