### PR TITLE
Allow poorly-signed packages to install on EL8+ w/FIPS

### DIFF
--- a/forescout-secure-connector/package/install.sls
+++ b/forescout-secure-connector/package/install.sls
@@ -18,9 +18,26 @@ ForeScout SecureConnector Archive Extracted:
     - group: root
     - mode: 0700
 
+Relax pkgverify options:
+  file.managed:
+    - contents: '%_pkgverify_level none'
+    - group: 'root'
+    - mode: '0600'
+    - name: '/etc/rpm/macros.verify'
+    - user: 'root'
+    - selinux:
+        serange: 's0'
+        serole: 'object_r'
+        setype: 'etc_t'
+        seuser: 'system_u'
+    - unless:
+      - '[[ $( rpm -qf /etc/os-release --qf "%{release}\n" | sed "s/^.*\.el//" ) -lt 8 ]]'
+
 {%- if forescout.package.daemon.get('source') %}
 ForeScout SecureConnector Daemon Installed:
   pkg.installed:
+    - setopt:
+      - tsflags=nocrypto
     - sources:
       - {{ forescout.package.daemon.name }}: {{ forescout.package.daemon.source }}
     - skip_verify: True
@@ -35,3 +52,7 @@ ForeScout SecureConnector Installed:
     - require:
       - archive: ForeScout SecureConnector Archive Extracted
       - pkg: ForeScout SecureConnector Dependencies Installed
+
+Restore pkgverify options:
+  file.absent:
+    - name: '/etc/rpm/macros.verify'

--- a/forescout-secure-connector/package/install.sls
+++ b/forescout-secure-connector/package/install.sls
@@ -1,6 +1,6 @@
 {#- Get the `tplroot` from `tpldir` #}
 {%- set tplroot = tpldir.split('/')[0] %}
-{%- set RpmVrfySetting = '/etc/rpm/forescout-daemon.rpm-verify' %}
+{%- set RpmVrfySetting = '/etc/rpm/macros.verify' %}
 
 {%- from tplroot ~ "/map.jinja" import mapdata as forescout with context %}
 

--- a/forescout-secure-connector/package/install.sls
+++ b/forescout-secure-connector/package/install.sls
@@ -1,5 +1,6 @@
 {#- Get the `tplroot` from `tpldir` #}
 {%- set tplroot = tpldir.split('/')[0] %}
+{%- set RpmVrfySetting = '/etc/rpm/forescout-daemon.rpm-verify' %}
 
 {%- from tplroot ~ "/map.jinja" import mapdata as forescout with context %}
 
@@ -23,7 +24,7 @@ Relax pkgverify options:
     - contents: '%_pkgverify_level none'
     - group: 'root'
     - mode: '0600'
-    - name: '/etc/rpm/macros.verify'
+    - name: '{{ RpmVrfySetting }}'
     - user: 'root'
     - selinux:
         serange: 's0'
@@ -55,4 +56,4 @@ ForeScout SecureConnector Installed:
 
 Restore pkgverify options:
   file.absent:
-    - name: '/etc/rpm/macros.verify'
+    - name: '{{ RpmVrfySetting }}'

--- a/forescout-secure-connector/package/install.sls
+++ b/forescout-secure-connector/package/install.sls
@@ -60,4 +60,4 @@ Restore pkgverify options:
   file.absent:
     - name: '{{ RpmVrfySetting }}'
     - require:
-      - pkg: ForeScout SecureConnector Installed
+      - cmd: ForeScout SecureConnector Installed

--- a/forescout-secure-connector/package/install.sls
+++ b/forescout-secure-connector/package/install.sls
@@ -60,4 +60,4 @@ Restore pkgverify options:
   file.absent:
     - name: '{{ RpmVrfySetting }}'
     - require:
-      - pkg: ForeScout SecureConnector Daemon Installed
+      - pkg: ForeScout SecureConnector Installed

--- a/forescout-secure-connector/package/install.sls
+++ b/forescout-secure-connector/package/install.sls
@@ -42,6 +42,8 @@ ForeScout SecureConnector Daemon Installed:
     - sources:
       - {{ forescout.package.daemon.name }}: {{ forescout.package.daemon.source }}
     - skip_verify: True
+    - require:
+      - file: Relax pkgverify options
     - require_in:
       - cmd: ForeScout SecureConnector Installed
 {%- endif %}
@@ -57,3 +59,5 @@ ForeScout SecureConnector Installed:
 Restore pkgverify options:
   file.absent:
     - name: '{{ RpmVrfySetting }}'
+    - require:
+      - pkg: ForeScout SecureConnector Daemon Installed


### PR DESCRIPTION
Until ForeScout's RPM is fixed to have a FIPS-compatible signature _and_ envelope-digest, need to work around the gap by ensuring that:

- `%_pkgverify_level` is set to `none` in the `/etc/rpm/macros.verify` file
- The `tsflags=nocrypto` yum-option is set
