### PR TITLE
Add logic to change logging location

### DIFF
--- a/forescout-secure-connector/config/init.sls
+++ b/forescout-secure-connector/config/init.sls
@@ -1,0 +1,2 @@
+include:
+  - .log

--- a/forescout-secure-connector/config/log.sls
+++ b/forescout-secure-connector/config/log.sls
@@ -27,4 +27,3 @@ Forescout Zap Default Log-Dir:
       - '[[ -d /usr/lib/forescout/bin/log ]]'
     - require:
       - file: ForeScout OS Log-Dir Setup
-      - cmd: ForeScout SecureConnector Installed

--- a/forescout-secure-connector/config/log.sls
+++ b/forescout-secure-connector/config/log.sls
@@ -1,0 +1,30 @@
+ForeScout OS Log-Dir Setup:
+  file.directory:
+    - group: 'root'
+    - mode: '0755'
+    - name: '/var/log/forescout'
+    - selinux:
+        serange: 's0'
+        serole: 'object_r'
+        setype: 'lib_t'
+        seuser: 'system_u'
+
+ForeScout Symlink to OS Log-Dir:
+  file.symlink:
+    - group: 'root'
+    - makedirs: True
+    - mode: '0755'
+    - name: '/usr/lib/forescout/bin/log'
+    - require:
+      - file: Forescout Zap Default Log-Dir
+    - target: '/var/log/forescout'
+    - user: 'root'
+
+Forescout Zap Default Log-Dir:
+  file.absent:
+    - name: '/usr/lib/forescout/bin/log'
+    - onlyif:
+      - '[[ -d /usr/lib/forescout/bin/log ]]'
+    - require:
+      - file: ForeScout OS Log-Dir Setup
+      - cmd: ForeScout SecureConnector Installed

--- a/forescout-secure-connector/init.sls
+++ b/forescout-secure-connector/init.sls
@@ -1,3 +1,4 @@
 include:
   - .package
   - .service
+  - .config

--- a/forescout-secure-connector/package/install.sls
+++ b/forescout-secure-connector/package/install.sls
@@ -4,23 +4,11 @@
 
 {%- from tplroot ~ "/map.jinja" import mapdata as forescout with context %}
 
-ForeScout OS Log-Dir Setup:
-  file.directory:
-    - group: 'root'
-    - mode: '0755'
-    - name: '/var/log/forescout'
-    - selinux:
-        serange: 's0'
-        serole: 'object_r'
-        setype: 'lib_t'
-        seuser: 'system_u'
-
 ForeScout SecureConnector Dependencies Installed:
   pkg.installed:
     - pkgs:
         - bzip2
         - wget
-    - user: 'root'
 
 ForeScout SecureConnector Archive Extracted:
   archive.extracted:
@@ -67,26 +55,6 @@ ForeScout SecureConnector Installed:
     - require:
       - archive: ForeScout SecureConnector Archive Extracted
       - pkg: ForeScout SecureConnector Dependencies Installed
-
-ForeScout Symlink to OS Log-Dir:
-  file.symlink:
-    - group: 'root'
-    - makedirs: True
-    - mode: '0755'
-    - name: '/usr/lib/forescout/bin/log'
-    - require:
-      - file: Forescout Zap Default Log-Dir
-    - target: '/var/log/forescout'
-    - user: 'root'
-
-Forescout Zap Default Log-Dir:
-  file.absent:
-    - name: '/usr/lib/forescout/bin/log'
-    - onlyif:
-      - '[[ -d /usr/lib/forescout/bin/log ]]'
-    - require:
-      - file: ForeScout OS Log-Dir Setup
-      - cmd: ForeScout SecureConnector Installed
 
 Restore pkgverify options:
   file.absent:

--- a/forescout-secure-connector/package/install.sls
+++ b/forescout-secure-connector/package/install.sls
@@ -4,11 +4,23 @@
 
 {%- from tplroot ~ "/map.jinja" import mapdata as forescout with context %}
 
+ForeScout OS Log-Dir Setup:
+  file.directory:
+    - group: 'root'
+    - mode: '0755'
+    - name: '/var/log/forescout'
+    - selinux:
+        serange: 's0'
+        serole: 'object_r'
+        setype: 'lib_t'
+        seuser: 'system_u'
+
 ForeScout SecureConnector Dependencies Installed:
   pkg.installed:
     - pkgs:
         - bzip2
         - wget
+    - user: 'root'
 
 ForeScout SecureConnector Archive Extracted:
   archive.extracted:
@@ -55,6 +67,26 @@ ForeScout SecureConnector Installed:
     - require:
       - archive: ForeScout SecureConnector Archive Extracted
       - pkg: ForeScout SecureConnector Dependencies Installed
+
+ForeScout Symlink to OS Log-Dir:
+  file.symlink:
+    - group: 'root'
+    - makedirs: True
+    - mode: '0755'
+    - name: '/usr/lib/forescout/bin/log'
+    - require:
+      - file: Forescout Zap Default Log-Dir
+    - target: '/var/log/forescout'
+    - user: 'root'
+
+Forescout Zap Default Log-Dir:
+  file.absent:
+    - name: '/usr/lib/forescout/bin/log'
+    - onlyif:
+      - '[[ -d /usr/lib/forescout/bin/log ]]'
+    - require:
+      - file: ForeScout OS Log-Dir Setup
+      - cmd: ForeScout SecureConnector Installed
 
 Restore pkgverify options:
   file.absent:


### PR DESCRIPTION
Adds process that:
1. Creates `/var/log/forescout`
2. Conditionally-nuke `/usr/lib/forescout/bin/log` (condition: if already exists and is a directory)
3. Creates a new `/usr/lib/forescout/bin/log` as symlink pointing to `/var/log/forescout`

Closes #11 