### PR TITLE
Add a fix-ownership cleanup step

### DIFF
--- a/forescout-secure-connector/config/fix-ownership.sls
+++ b/forescout-secure-connector/config/fix-ownership.sls
@@ -1,0 +1,8 @@
+Fix ForeScout Ownerships:
+  file.directory:
+    - name: '/usr/lib/forescout'
+    - user: 'root'
+    - group: 'root'
+    - recurse:
+      - user
+      - group

--- a/forescout-secure-connector/config/init.sls
+++ b/forescout-secure-connector/config/init.sls
@@ -1,2 +1,3 @@
 include:
   - .log
+  - .fix-ownership


### PR DESCRIPTION
Adds a "fix" state to the `config` stage. This state is a simple, recursive-chown type of state using SaltStack's [`file.directory`](https://docs.saltproject.io/en/latest/ref/states/all/salt.states.file.html#salt.states.file.directory) state to recursively fix the user- and group-ownership of files within the `'/usr/lib/forescout` directory-hierarchy.

Closes #16