### PR TITLE
Removes selinux config for systemd service file due to equivalency rule

### DIFF
--- a/forescout-secure-connector/package/install.sls
+++ b/forescout-secure-connector/package/install.sls
@@ -62,11 +62,6 @@ ForeScout SecureConnector Systemd Service File:
     - user: root
     - group: root
     - mode: 0644
-    - selinux:
-        serange: 's0'
-        serole: 'object_r'
-        setype: 'etc_t'
-        seuser: 'system_u'
 
 ForeScout SecureConnector Installed:
   cmd.run:


### PR DESCRIPTION
See also: https://github.com/saltstack/salt/issues/62875